### PR TITLE
fix: handle case where get_deployed_resources is called on a resource_type not in cluster

### DIFF
--- a/tests/integration/test_kubernetes_resource_manager.py
+++ b/tests/integration/test_kubernetes_resource_manager.py
@@ -12,6 +12,7 @@ from lightkube.codecs import load_all_yaml
 from lightkube.core.exceptions import ApiError
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Namespace, Pod, Service
+
 from lightkube_extensions.batch import KubernetesResourceManager, create_charm_default_labels
 
 # Note: all tests require a Kubernetes cluster to run against.

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -5,6 +5,7 @@ import pytest
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Namespace
+
 from lightkube_extensions.batch import apply_many, delete_many
 
 namespaced_resource = StatefulSet(

--- a/tests/unit/test_kubernetes_resource_manager.py
+++ b/tests/unit/test_kubernetes_resource_manager.py
@@ -15,6 +15,7 @@ from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
 from lightkube.resources.admissionregistration_v1 import MutatingWebhookConfiguration
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Pod, Service
+
 from lightkube_extensions.batch import KubernetesResourceManager
 from lightkube_extensions.batch._kubernetes_resource_manager import (
     _add_labels_to_resources,


### PR DESCRIPTION
During teardown, especially when destroying a model, we can have a race condition where resource_type's owner may have already been deleted and thus the resource_type CRD has been removed.  For that reason, ignore 404 errors here and just proceed to the next resource
