### PR TITLE
fix!: shorten long label names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
   "lightkube>=0.11.0",
   "jinja2",
+  "charmed-service-mesh-helpers"
 ]
 
 # Testing tools configuration

--- a/src/lightkube_extensions/batch/_kubernetes_resource_manager.py
+++ b/src/lightkube_extensions/batch/_kubernetes_resource_manager.py
@@ -5,9 +5,10 @@
 import copy
 import functools
 import logging
-from typing import Callable, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple
 
 import httpx
+from charmed_service_mesh_helpers import charm_kubernetes_label
 from lightkube import ApiError, Client
 from lightkube.core.resource import NamespacedResource, Resource, api_info
 from lightkube.types import PatchType
@@ -276,10 +277,15 @@ class KubernetesResourceManager:
         self.patch(resources=resources, force=force, patch_type=patch_type)
 
 
-def create_charm_default_labels(application_name: str, model_name: str, scope: str) -> dict:
+def create_charm_default_labels(
+    application_name: str, model_name: str, scope: str
+) -> Dict[str, str]:
     """Return a default label style for the KubernetesResourceHandler label selector."""
+    instance_label = charm_kubernetes_label(
+        model_name=model_name, app_name=application_name, separator="-"
+    )
     return {
-        "app.kubernetes.io/instance": f"{application_name}-{model_name}",
+        "app.kubernetes.io/instance": instance_label,
         "kubernetes-resource-handler-scope": scope,
     }
 

--- a/tests/unit/test_kubernetes_resource_manager.py
+++ b/tests/unit/test_kubernetes_resource_manager.py
@@ -25,6 +25,7 @@ from lightkube_extensions.batch._kubernetes_resource_manager import (
     _in_left_not_right,
     _validate_resources,
 )
+from src.lightkube_extensions.batch._kubernetes_resource_manager import create_charm_default_labels
 
 data_dir = Path(__file__).parent.joinpath("data")
 
@@ -400,3 +401,15 @@ def test_KubernetesResourceManager_wraps_transport_error(method, kwargs):  # noq
         getattr(krm, method)(**kwargs)
 
     assert isinstance(exc_info.value.__cause__, httpx.TransportError)
+
+
+@pytest.mark.parametrize("model_name", ["a", "b" * 63, "c" * 64], ids=["m1", "m63", "m64"])
+@pytest.mark.parametrize("app_name", ["a", "b" * 63, "c" * 64], ids=["a1", "a63", "a64"])
+def test_create_charm_default_labels__maxlength(model_name, app_name):
+    labels = create_charm_default_labels(app_name, model_name, "testscope")
+    assert len(labels["app.kubernetes.io/instance"]) <= 63
+
+
+def test_create_charm_default_labels__short_names():
+    labels = create_charm_default_labels("abcde", "fghij", "testscope")
+    assert labels["app.kubernetes.io/instance"] == "fghij-abcde"


### PR DESCRIPTION


## Issue

Kubernetes labels should be no longer than 63 characters. This issue caused failures in [another repository](https://github.com/canonical/istio-beacon-k8s-operator/actions/runs/23727475415/job/69114150973?pr=159).

## Solution

The solution reuses a [helper function](https://github.com/canonical/charmed-service-mesh-helpers/blob/892782e3f40ff7b23d7c3a7f8c875623f222b84b/src/charmed_service_mesh_helpers/labels.py#L61) from `charmed_service_mesh_helpers`.

Since the fix reuses a helper method, the label is now "<model_name>-<app_name>" instead of the old "<app_name>-<model_name>" for cases not requiring shortening.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions

New unit tests are added to cover the changes.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
